### PR TITLE
New defaults and options for auto formatting

### DIFF
--- a/src/components/CSSVariableProvider.tsx
+++ b/src/components/CSSVariableProvider.tsx
@@ -37,6 +37,21 @@ type Props<V extends { [key: string]: any }> = {
    * check and prefix the variable name with `--` if it hasn't been included.
    */
   isFlattenedAndFormatted?: boolean;
+  /**
+   * When defined, each segment of the object being flattened will include this value.  For example, { color: { main: 'red' } }
+   * would become '--color-main: red;'
+   *
+   * defaults to `-` unless varTitleCase is true (then it would default to `undefined`)
+   */
+  varSeparator?: string;
+  /**
+   * When defined, each segment of the object is transformed to title case.  For example, { color: { main: 'red' } }
+   * would become '--colorMain: red;'
+   *
+   * defaults to `false`, setting this to `true` will cause the varSeparator to be `undefined` by default
+   */
+  varTitleCase?: boolean;
+
   children: React.ReactNode;
 };
 
@@ -111,8 +126,22 @@ export default React.memo(function CSSVariableProvider<
       isFlattened: !vars ? true : !!isFlattened,
       isFlattenedAndFormatted: !vars ? true : !!isFlattenedAndFormatted,
       setOnRoot: !!setOnRoot,
+      varSeparator:
+        props.varTitleCase !== true && props.varSeparator === undefined
+          ? '-'
+          : props.varSeparator,
+      varTitleCase: !!props.varTitleCase,
     }),
-    [uid, vars, styleVars, isFlattened, isFlattenedAndFormatted, setOnRoot],
+    [
+      uid,
+      vars,
+      styleVars,
+      isFlattened,
+      isFlattenedAndFormatted,
+      setOnRoot,
+      props.varSeparator,
+      props.varTitleCase,
+    ],
   );
 
   const refToUse = React.useMemo(() => {

--- a/src/hooks/useFlattenedObject.ts
+++ b/src/hooks/useFlattenedObject.ts
@@ -9,7 +9,14 @@ export function useFlattenedObject(
   useDebugValue('[CSSVariableProvider] | useFlattenedObject');
 
   const flattenedVars = useMemo(
-    () => (config.isFlattened ? vars : createFlattenedStyleVarObject(vars)),
+    () =>
+      config.isFlattened
+        ? vars
+        : createFlattenedStyleVarObject(
+            vars,
+            config.varSeparator,
+            config.varTitleCase,
+          ),
     [config.isFlattened, vars],
   );
 

--- a/src/utils/flatten-object.ts
+++ b/src/utils/flatten-object.ts
@@ -4,6 +4,7 @@
  */
 export default function flattenObject(
   value: Record<string, any>,
+  separator = '',
   toTitleCase = true,
   prefix = '',
   i = 0,
@@ -12,16 +13,23 @@ export default function flattenObject(
   return Object.keys(value).reduce((p, c) => {
     let key: string;
     if (toTitleCase && i !== 0) {
-      key = c.replace(
+      key = `${separator}${c.replace(
         /\w\S*/g,
         (txt) => txt.charAt(0).toUpperCase() + txt.substr(1),
-      );
+      )}`;
     } else {
-      key = c;
+      key = i !== 0 ? `${separator}${c}` : c;
     }
     if (value[c] !== undefined && value[c] !== null) {
       if (typeof value[c] === 'object') {
-        flattenObject(value[c], toTitleCase, `${prefix}${key}`, i + 1, p);
+        flattenObject(
+          value[c],
+          separator,
+          toTitleCase,
+          `${prefix}${key}`,
+          i + 1,
+          p,
+        );
       } else {
         key = prefix ? `${prefix}${key}` : key;
         if (Object.prototype.hasOwnProperty.call(p, key)) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -18,7 +18,7 @@ export function* walkContexts(
 }
 
 export const getVarName = (name: string, isNameFormatted?: boolean) =>
-  isNameFormatted || name[0] === '-' ? name : `--${name}`;
+  isNameFormatted || name.startsWith('--') ? name : `--${name}`;
 
 export const getVarValue = (value: string | null | number): null | string =>
   value === null ? value : String(value);
@@ -44,8 +44,10 @@ export function getElementRef(
 
 export function createFlattenedStyleVarObject(
   vars: Record<string, any>,
+  separator = '',
+  titleCase = false,
 ): { [key: string]: string | number } {
-  const flattened = flattenObject(vars, true, '--');
+  const flattened = flattenObject(vars, separator, titleCase, '--');
   return flattened;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,6 +45,8 @@ export type CSSVariableContextConfig = {
   isFlattened: boolean;
   isFlattenedAndFormatted: boolean;
   setOnRoot: boolean;
+  varSeparator?: string;
+  varTitleCase?: boolean;
 };
 
 export type CSSVariableContext<

--- a/tests/quick.ts
+++ b/tests/quick.ts
@@ -1,7 +1,16 @@
 // For quick testing and running of typescript snippets
+import { createFlattenedStyleVarObject } from '../src/utils/helpers';
 
 async function run() {
-  /* Run Snippet Here */
+  console.log(
+    createFlattenedStyleVarObject({
+      color: {
+        primary: {
+          main: 'black',
+        },
+      },
+    }),
+  );
 }
 
 run();


### PR DESCRIPTION
When using the auto formatting, the previous default was to transform objects to title case:

```
color: {
  primary: {
     main: 'red'
  }
}
```

Previous Default: `--colorPrimaryMain: red;`
New Default: `--color-primary-main: red;`

With this two new props control this.  `varTitleCase` defaulting to false can be set true to get previous behavior again.  
Using `varSeparator` can control the separator such that `varSeparator="_"` would produce `--color_primary_main: red;`